### PR TITLE
Added timing for 800x600@56Hz for exact 48 MHz USB/SDIO clock

### DIFF
--- a/timing.cc
+++ b/timing.cc
@@ -63,4 +63,34 @@ Timing const timing_vesa_800x600_60hz = {
   .vsync_polarity   = Timing::Polarity::positive,
 };
 
+Timing const timing_800x600_56hz = {
+  .clock_config = {
+    .crystal_hz = 8000000,  // external crystal Hz
+    .crystal_divisor = 4,   // divide down to 2Mhz
+    .vco_multiplier = 144,  // multiply up to 288MHz VCO
+    .general_divisor = 2,   // divide by 2 for 144MHz CPU clock
+    .pll48_divisor = 6,     // divide by 6 for 48MHz SDIO clock
+    .ahb_divisor = 1,       // divide CPU clock by 1 for 144MHz AHB clock
+    .apb1_divisor = 4,      // divide CPU clock by 4 for 36MHz APB1 clock.
+    .apb2_divisor = 2,      // divide CPU clock by 2 for 72MHz APB2 clock.
+
+    .flash_latency = 4,     // 4 wait states for 144MHz at 3.3V.
+  },
+
+  .cycles_per_pixel = 4,
+
+  .line_pixels       = 1024,
+  .sync_pixels       = 72,
+  .back_porch_pixels = 128,
+  .video_lead        = 22,
+  .video_pixels      = 800,
+  .hsync_polarity    = Timing::Polarity::positive,
+
+  .vsync_start_line = 1,
+  .vsync_end_line   = 1 + 2,
+  .video_start_line = 1 + 2 + 22,
+  .video_end_line   = 1 + 2 + 22 + 600,
+  .vsync_polarity   = Timing::Polarity::positive,
+};
+
 }  // namespace vga

--- a/timing.h
+++ b/timing.h
@@ -71,6 +71,9 @@ struct Timing {
 extern Timing const timing_vesa_640x480_60hz;
 extern Timing const timing_vesa_800x600_60hz;
 
+// This non-VESA mode is useful if you need exactly 48 MHz for USB clock
+extern Timing const timing_800x600_56hz;
+
 }  // namespace vga
 
 #endif  // VGA_TIMING_H


### PR DESCRIPTION
Added timing for 800x600@56Hz for exact 48 MHz USB/SDIO clock. I tested it on 3 different monitors (Samsung and Asus) and it looks great.
The 2 modes that are defined in timing.h make "48MHz-ish" clock, the new mode is exact 48 MHz.

